### PR TITLE
Fix Postgres data_type query

### DIFF
--- a/eventuate-common-jdbc/src/main/java/io/eventuate/common/jdbc/sqldialect/PostgresDialect.java
+++ b/eventuate-common-jdbc/src/main/java/io/eventuate/common/jdbc/sqldialect/PostgresDialect.java
@@ -67,13 +67,10 @@ public class PostgresDialect extends DefaultEventuateSqlDialect {
     return columnTypeCache.computeIfAbsent(
             new ColumnCacheKey(eventuateSchema.getEventuateDatabaseSchema(), unqualifiedTable, column),
             columnCacheKey -> {
-              String informationSchema = eventuateSchema.qualifyTable("information_schema");
-
-              final String sql = String
-                      .format("select data_type from %s.columns where table_name = ? and column_name = ?", informationSchema);
+              String sql = "select data_type from information_schema.columns where table_schema = ? and table_name = ? and column_name = ?";
 
               return (String) eventuateJdbcStatementExecutor
-                      .queryForList(sql, unqualifiedTable, column)
+                      .queryForList(sql, eventuateSchema.getEventuateDatabaseSchema(), unqualifiedTable, column)
                       .get(0)
                       .get("data_type");
             });


### PR DESCRIPTION
A previous query for fetching `data_type` was incorrectly resolving table name to `eventuate.information_schema.columns`:
```
select data_type from eventuate.information_schema.columns where table_name = ? and column_name = ?
```

The fix always directs the query to `information_schema.columns` table in Postgres.