### PR TITLE
#53: (database id generation) The auto generated values must greater than any existing messages.

### DIFF
--- a/mariadb/4.initialize-database-db-id.sql
+++ b/mariadb/4.initialize-database-db-id.sql
@@ -10,6 +10,9 @@ CREATE TABLE new_message (
   creation_time BIGINT
 );
 
+INSERT INTO new_message (id, dbid, destination, headers, payload, published, creation_time)
+    VALUES ('', ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000), 'CDC-IGNORED', '{}', '\"ID-GENERATION-STARTING-VALUE\"', 1, ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000));
+
 INSERT INTO new_message (id, destination, headers, payload, published, creation_time)
     SELECT id, destination, headers, payload, published, creation_time FROM message;
 
@@ -31,6 +34,9 @@ create table new_events (
   published TINYINT DEFAULT 0
 );
 
+INSERT INTO new_events (id, event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published)
+    VALUES (ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000), '', 'CDC-IGNORED', 'ID-GENERATION-STARTING-VALUE', 'CDC-IGNORED', 'CDC-IGNORED', '', '', 1);
+
 INSERT INTO new_events (event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published)
     SELECT event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published FROM events;
 
@@ -41,4 +47,3 @@ ALTER TABLE new_events RENAME TO events;
 CREATE INDEX events_idx ON events(entity_type, entity_id, id);
 
 CREATE INDEX events_published_idx ON events(published, id);
-

--- a/mssql/4.setup-db-id.sql
+++ b/mssql/4.setup-db-id.sql
@@ -3,13 +3,23 @@ GO
 
 CREATE TABLE eventuate.new_message (
   id VARCHAR(767),
-  dbid BIGINT IDENTITY(1,1) PRIMARY KEY,
+  dbid BIGINT IDENTITY(1, 1) PRIMARY KEY,
   destination NVARCHAR(MAX) NOT NULL,
   headers NVARCHAR(MAX) NOT NULL,
   payload NVARCHAR(MAX) NOT NULL,
   published SMALLINT DEFAULT 0,
   creation_time BIGINT
 );
+GO
+
+SET IDENTITY_INSERT eventuate.new_message ON;
+GO
+
+INSERT INTO eventuate.new_message (id, dbid, destination, headers, payload, published, creation_time)
+    VALUES ('', (DATEDIFF_BIG(ms, '1970-01-01', GETUTCDATE())), 'CDC-IGNORED', '{}', '\"ID-GENERATION-STARTING-VALUE\"', 1, (DATEDIFF_BIG(ms, '1970-01-01', GETUTCDATE())));
+GO
+
+SET IDENTITY_INSERT eventuate.new_message OFF;
 GO
 
 INSERT INTO eventuate.new_message (id, destination, headers, payload, published, creation_time)
@@ -26,7 +36,7 @@ CREATE INDEX message_published_idx ON eventuate.message(published, dbid);
 GO
 
 create table eventuate.new_events (
-  id BIGINT IDENTITY(1,1) PRIMARY KEY,
+  id BIGINT IDENTITY(1, 1) PRIMARY KEY,
   event_id varchar(1000),
   event_type varchar(1000),
   event_data varchar(1000) NOT NULL,
@@ -36,6 +46,16 @@ create table eventuate.new_events (
   metadata VARCHAR(1000),
   published TINYINT DEFAULT 0
 );
+GO
+
+SET IDENTITY_INSERT eventuate.new_events ON;
+GO
+
+INSERT INTO eventuate.new_events (id, event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published)
+    VALUES ((DATEDIFF_BIG(ms, '1970-01-01', GETUTCDATE())), '', 'CDC-IGNORED', 'ID-GENERATION-STARTING-VALUE', 'CDC-IGNORED', 'CDC-IGNORED', '', '', 1);
+GO
+
+SET IDENTITY_INSERT eventuate.new_events OFF;
 GO
 
 INSERT INTO eventuate.new_events (event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published)

--- a/mysql/0.activate-additional-scripts.sh
+++ b/mysql/0.activate-additional-scripts.sh
@@ -8,6 +8,11 @@ fi
 
 if [[ "${USE_DB_ID}" == "true" ]]; then
   rm /docker-entrypoint-initdb.d/4.initialize-database-db-id.sql
+  sed -i -e "s/<<CURRENT_TIME_IN_MILLISECONDS>>/$(date +%s000)/g" /additional-scripts/4.initialize-database-db-id.sql
   cp /additional-scripts/4.initialize-database-db-id.sql docker-entrypoint-initdb.d
+  echo "db id migration script"
+  echo "----------------------"
+  cat /docker-entrypoint-initdb.d/4.initialize-database-db-id.sql
+  echo "----------------------"
   echo "4.initialize-database-db-id.sql is activated"
 fi

--- a/mysql/0.activate-additional-scripts.sh
+++ b/mysql/0.activate-additional-scripts.sh
@@ -8,11 +8,6 @@ fi
 
 if [[ "${USE_DB_ID}" == "true" ]]; then
   rm /docker-entrypoint-initdb.d/4.initialize-database-db-id.sql
-  sed -i -e "s/<<CURRENT_TIME_IN_MILLISECONDS>>/$(date +%s000)/g" /additional-scripts/4.initialize-database-db-id.sql
   cp /additional-scripts/4.initialize-database-db-id.sql docker-entrypoint-initdb.d
-  echo "db id migration script"
-  echo "----------------------"
-  cat /docker-entrypoint-initdb.d/4.initialize-database-db-id.sql
-  echo "----------------------"
   echo "4.initialize-database-db-id.sql is activated"
 fi

--- a/mysql/4.initialize-database-db-id.sql
+++ b/mysql/4.initialize-database-db-id.sql
@@ -11,7 +11,7 @@ CREATE TABLE new_message (
 );
 
 INSERT INTO new_message (id, dbid, destination, headers, payload, published, creation_time)
-    VALUES ('', ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000), '', '\"\"', '\"\"', 1, ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000));
+    VALUES ('', ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000), 'CDC-IGNORED', '{}', '\"ID-GENERATION-STARTING-VALUE\"', 1, ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000));
 
 INSERT INTO new_message (id, destination, headers, payload, published, creation_time)
     SELECT id, destination, headers, payload, published, creation_time FROM message;
@@ -35,7 +35,7 @@ create table new_events (
 );
 
 INSERT INTO new_events (id, event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published)
-    VALUES (ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000), '', '', '', '', '', '', '', 1);
+    VALUES (ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000), '', 'CDC-IGNORED', 'ID-GENERATION-STARTING-VALUE', 'CDC-IGNORED', 'CDC-IGNORED', '', '', 1);
 
 INSERT INTO new_events (event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published)
     SELECT event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published FROM events;

--- a/mysql/4.initialize-database-db-id.sql
+++ b/mysql/4.initialize-database-db-id.sql
@@ -8,7 +8,10 @@ CREATE TABLE new_message (
   payload LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   published SMALLINT DEFAULT 0,
   creation_time BIGINT
-) AUTO_INCREMENT = <<CURRENT_TIME_IN_MILLISECONDS>>;
+);
+
+INSERT INTO new_message (id, dbid, destination, headers, payload, published, creation_time)
+    VALUES ('', ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000), '', '\"\"', '\"\"', 1, ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000));
 
 INSERT INTO new_message (id, destination, headers, payload, published, creation_time)
     SELECT id, destination, headers, payload, published, creation_time FROM message;
@@ -16,7 +19,6 @@ INSERT INTO new_message (id, destination, headers, payload, published, creation_
 DROP TABLE message;
 
 ALTER TABLE new_message RENAME TO message;
-
 
 CREATE INDEX message_published_idx ON message(published, dbid);
 
@@ -30,7 +32,10 @@ create table new_events (
   triggering_event VARCHAR(1000),
   metadata VARCHAR(1000),
   published TINYINT DEFAULT 0
-) AUTO_INCREMENT = <<CURRENT_TIME_IN_MILLISECONDS>>;
+);
+
+INSERT INTO new_events (id, event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published)
+    VALUES (ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000), '', '', '', '', '', '', '', 1);
 
 INSERT INTO new_events (event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published)
     SELECT event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published FROM events;

--- a/mysql/4.initialize-database-db-id.sql
+++ b/mysql/4.initialize-database-db-id.sql
@@ -8,7 +8,7 @@ CREATE TABLE new_message (
   payload LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   published SMALLINT DEFAULT 0,
   creation_time BIGINT
-);
+) AUTO_INCREMENT = <<CURRENT_TIME_IN_MILLISECONDS>>;
 
 INSERT INTO new_message (id, destination, headers, payload, published, creation_time)
     SELECT id, destination, headers, payload, published, creation_time FROM message;
@@ -16,6 +16,7 @@ INSERT INTO new_message (id, destination, headers, payload, published, creation_
 DROP TABLE message;
 
 ALTER TABLE new_message RENAME TO message;
+
 
 CREATE INDEX message_published_idx ON message(published, dbid);
 
@@ -29,7 +30,7 @@ create table new_events (
   triggering_event VARCHAR(1000),
   metadata VARCHAR(1000),
   published TINYINT DEFAULT 0
-);
+) AUTO_INCREMENT = <<CURRENT_TIME_IN_MILLISECONDS>>;
 
 INSERT INTO new_events (event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published)
     SELECT event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published FROM events;

--- a/postgres/5.initialize-database-db-id.sql
+++ b/postgres/5.initialize-database-db-id.sql
@@ -1,12 +1,18 @@
+CREATE SEQUENCE eventuate.message_table_id_sequence START 1;
+
+select setval('eventuate.message_table_id_sequence', (ROUND(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000))::BIGINT);
+
 CREATE TABLE eventuate.new_message (
   id VARCHAR(1000),
-  dbid bigserial PRIMARY KEY,
+  dbid BIGINT NOT NULL DEFAULT nextval('eventuate.message_table_id_sequence') PRIMARY KEY,
   destination TEXT NOT NULL,
   headers TEXT NOT NULL,
   payload TEXT NOT NULL,
   published SMALLINT DEFAULT 0,
   creation_time BIGINT
 );
+
+ALTER SEQUENCE eventuate.message_table_id_sequence OWNED BY eventuate.new_message.dbid;
 
 INSERT INTO eventuate.new_message (id, destination, headers, payload, published, creation_time)
     SELECT id, destination, headers, payload, published, creation_time FROM eventuate.message;
@@ -15,8 +21,12 @@ DROP TABLE eventuate.message;
 
 ALTER TABLE eventuate.new_message RENAME TO message;
 
+CREATE SEQUENCE eventuate.events_table_id_sequence START 1;
+
+select setval('eventuate.events_table_id_sequence', (ROUND(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000))::BIGINT);
+
 CREATE TABLE eventuate.new_events (
-  id bigserial PRIMARY KEY,
+  id BIGINT NOT NULL DEFAULT nextval('eventuate.events_table_id_sequence') PRIMARY KEY,
   event_id VARCHAR(1000),
   event_type VARCHAR(1000),
   event_data VARCHAR(1000) NOT NULL,
@@ -26,6 +36,8 @@ CREATE TABLE eventuate.new_events (
   metadata VARCHAR(1000),
   published SMALLINT DEFAULT 0
 );
+
+ALTER SEQUENCE eventuate.events_table_id_sequence OWNED BY eventuate.new_events.id;
 
 INSERT INTO eventuate.new_events (event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published)
     SELECT event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published FROM eventuate.events;


### PR DESCRIPTION
PR makes generated ids start with current time in milliseconds to solve #53