### PR TITLE
Db id migration script inserts events/messages into recreated tables ordered by old id

### DIFF
--- a/eventuate-common-spring-jdbc/src/test/java/io/eventuate/common/spring/jdbc/EventuateCommonJdbcOperationsTest.java
+++ b/eventuate-common-spring-jdbc/src/test/java/io/eventuate/common/spring/jdbc/EventuateCommonJdbcOperationsTest.java
@@ -65,6 +65,18 @@ public class EventuateCommonJdbcOperationsTest extends AbstractEventuateCommonJd
 
   @Test
   @Override
+  public void testGeneratedIdOfEventsTableRow() {
+    super.testGeneratedIdOfEventsTableRow();
+  }
+
+  @Test
+  @Override
+  public void testGeneratedIdOfMessageTableRow() {
+    super.testGeneratedIdOfMessageTableRow();
+  }
+
+  @Test
+  @Override
   public void testInsertIntoEventsTable() throws SQLException {
     super.testInsertIntoEventsTable();
   }

--- a/mariadb/4.initialize-database-db-id.sql
+++ b/mariadb/4.initialize-database-db-id.sql
@@ -14,7 +14,7 @@ INSERT INTO new_message (id, dbid, destination, headers, payload, published, cre
     VALUES ('', ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000), 'CDC-IGNORED', '{}', '\"ID-GENERATION-STARTING-VALUE\"', 1, ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000));
 
 INSERT INTO new_message (id, destination, headers, payload, published, creation_time)
-    SELECT id, destination, headers, payload, published, creation_time FROM message;
+    SELECT id, destination, headers, payload, published, creation_time FROM message ORDER BY id;
 
 DROP TABLE message;
 
@@ -38,7 +38,7 @@ INSERT INTO new_events (id, event_id, event_type, event_data, entity_type, entit
     VALUES (ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000), '', 'CDC-IGNORED', 'ID-GENERATION-STARTING-VALUE', 'CDC-IGNORED', 'CDC-IGNORED', '', '', 1);
 
 INSERT INTO new_events (event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published)
-    SELECT event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published FROM events;
+    SELECT event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published FROM events ORDER BY event_id;
 
 DROP TABLE events;
 

--- a/mssql/4.setup-db-id.sql
+++ b/mssql/4.setup-db-id.sql
@@ -23,7 +23,7 @@ SET IDENTITY_INSERT eventuate.new_message OFF;
 GO
 
 INSERT INTO eventuate.new_message (id, destination, headers, payload, published, creation_time)
-    SELECT id, destination, headers, payload, published, creation_time FROM eventuate.message;
+    SELECT id, destination, headers, payload, published, creation_time FROM eventuate.message ORDER BY id;
 GO
 
 DROP TABLE eventuate.message;
@@ -59,7 +59,7 @@ SET IDENTITY_INSERT eventuate.new_events OFF;
 GO
 
 INSERT INTO eventuate.new_events (event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published)
-    SELECT event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published FROM eventuate.events;
+    SELECT event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published FROM eventuate.events ORDER BY event_id;
 GO
 
 DROP TABLE eventuate.events;

--- a/mysql/4.initialize-database-db-id.sql
+++ b/mysql/4.initialize-database-db-id.sql
@@ -14,7 +14,7 @@ INSERT INTO new_message (id, dbid, destination, headers, payload, published, cre
     VALUES ('', ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000), 'CDC-IGNORED', '{}', '\"ID-GENERATION-STARTING-VALUE\"', 1, ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000));
 
 INSERT INTO new_message (id, destination, headers, payload, published, creation_time)
-    SELECT id, destination, headers, payload, published, creation_time FROM message;
+    SELECT id, destination, headers, payload, published, creation_time FROM message ORDER BY id;
 
 DROP TABLE message;
 
@@ -38,7 +38,7 @@ INSERT INTO new_events (id, event_id, event_type, event_data, entity_type, entit
     VALUES (ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000), '', 'CDC-IGNORED', 'ID-GENERATION-STARTING-VALUE', 'CDC-IGNORED', 'CDC-IGNORED', '', '', 1);
 
 INSERT INTO new_events (event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published)
-    SELECT event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published FROM events;
+    SELECT event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published FROM events ORDER BY event_id;
 
 DROP TABLE events;
 

--- a/postgres/5.initialize-database-db-id.sql
+++ b/postgres/5.initialize-database-db-id.sql
@@ -15,7 +15,7 @@ CREATE TABLE eventuate.new_message (
 ALTER SEQUENCE eventuate.message_table_id_sequence OWNED BY eventuate.new_message.dbid;
 
 INSERT INTO eventuate.new_message (id, destination, headers, payload, published, creation_time)
-    SELECT id, destination, headers, payload, published, creation_time FROM eventuate.message;
+    SELECT id, destination, headers, payload, published, creation_time FROM eventuate.message ORDER BY id;
 
 DROP TABLE eventuate.message;
 
@@ -40,7 +40,7 @@ CREATE TABLE eventuate.new_events (
 ALTER SEQUENCE eventuate.events_table_id_sequence OWNED BY eventuate.new_events.id;
 
 INSERT INTO eventuate.new_events (event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published)
-    SELECT event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published FROM eventuate.events;
+    SELECT event_id, event_type, event_data, entity_type, entity_id, triggering_event, metadata, published FROM eventuate.events ORDER BY event_id;
 
 DROP TABLE eventuate.events;
 


### PR DESCRIPTION
fixes #55: events/messages should be inserted in the correct order
Moves generated id checks to separate methods
