### PR TITLE
Added verification that anchor event/message is created for mysql.

### DIFF
--- a/eventuate-common-jdbc/src/main/java/io/eventuate/common/jdbc/EventuateCommonJdbcOperations.java
+++ b/eventuate-common-jdbc/src/main/java/io/eventuate/common/jdbc/EventuateCommonJdbcOperations.java
@@ -22,6 +22,10 @@ public class EventuateCommonJdbcOperations {
     this.eventuateSqlDialect = eventuateSqlDialect;
   }
 
+  public EventuateSqlDialect getEventuateSqlDialect() {
+    return eventuateSqlDialect;
+  }
+
   public String insertIntoEventsTable(IdGenerator idGenerator,
                                       String entityId,
                                       String eventData,


### PR DESCRIPTION
PR: modifies testGeneratedIdOfEventsTableRow and testGeneratedIdOfMessageTableRow of EventuateCommonJdbcOperationsTest to check that anchor event/message is created, that is required for proper id value generation (started from current time).