### PR TITLE
#58: CircleCI Build #112 failure - java.lang.AssertionError: Row id s…

### DIFF
--- a/_build-and-test-all.sh
+++ b/_build-and-test-all.sh
@@ -14,6 +14,8 @@ fi
 function testJdbc() {
   ${docker}Up
 
+  sleep 30
+
   ./gradlew $* :eventuate-common-micronaut-data-jdbc:cleanTest :eventuate-common-micronaut-data-jdbc:test \
   :eventuate-common-micronaut-spring-jdbc:cleanTest :eventuate-common-micronaut-spring-jdbc:test \
   :eventuate-common-spring-jdbc:cleanTest :eventuate-common-spring-jdbc:test


### PR DESCRIPTION
…hould start from current time in milliseconds after migration (current time: 1607015506230, id: 15). https://github.com/eventuate-foundation/eventuate-common/issues/58#issuecomment-738849685. Temporary added timeout.