### PR TITLE
Added support for several drivers for eventuate sql dialects.

### DIFF
--- a/eventuate-common-jdbc/src/main/java/io/eventuate/common/jdbc/sqldialect/AbstractEventuateSqlDialect.java
+++ b/eventuate-common-jdbc/src/main/java/io/eventuate/common/jdbc/sqldialect/AbstractEventuateSqlDialect.java
@@ -6,24 +6,23 @@ import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Optional;
 import java.util.Set;
 
 public abstract class AbstractEventuateSqlDialect implements EventuateSqlDialect {
 
-  private Optional<String> driver;
+  private Set<String> drivers;
   private Set<String> names;
   private String customCurrentTimeInMillisecondsExpression;
 
-  public AbstractEventuateSqlDialect(Optional<String> driver, Set<String> names, String customCurrentTimeInMillisecondsExpression) {
-    this.driver = driver;
+  public AbstractEventuateSqlDialect(Set<String> drivers, Set<String> names, String customCurrentTimeInMillisecondsExpression) {
+    this.drivers = drivers;
     this.names = names;
     this.customCurrentTimeInMillisecondsExpression = customCurrentTimeInMillisecondsExpression;
   }
 
   @Override
   public boolean supports(String driver) {
-    return this.driver.map(d -> d.equals(driver)).orElse(false);
+    return drivers.contains(driver);
   }
 
   @Override

--- a/eventuate-common-jdbc/src/main/java/io/eventuate/common/jdbc/sqldialect/DefaultEventuateSqlDialect.java
+++ b/eventuate-common-jdbc/src/main/java/io/eventuate/common/jdbc/sqldialect/DefaultEventuateSqlDialect.java
@@ -1,12 +1,11 @@
 package io.eventuate.common.jdbc.sqldialect;
 
 import java.util.Collections;
-import java.util.Optional;
 
 public class DefaultEventuateSqlDialect extends AbstractEventuateSqlDialect {
 
   public DefaultEventuateSqlDialect(String customCurrentTimeInMillisecondsExpression) {
-    super(Optional.empty(), Collections.emptySet(), customCurrentTimeInMillisecondsExpression);
+    super(Collections.emptySet(), Collections.emptySet(), customCurrentTimeInMillisecondsExpression);
   }
 
   @Override

--- a/eventuate-common-jdbc/src/main/java/io/eventuate/common/jdbc/sqldialect/MsSqlDialect.java
+++ b/eventuate-common-jdbc/src/main/java/io/eventuate/common/jdbc/sqldialect/MsSqlDialect.java
@@ -1,12 +1,11 @@
 package io.eventuate.common.jdbc.sqldialect;
 
 import java.util.Collections;
-import java.util.Optional;
 
 public class MsSqlDialect extends AbstractEventuateSqlDialect {
 
   public MsSqlDialect() {
-    super(Optional.of("com.microsoft.sqlserver.jdbc.SQLServerDriver"),
+    super(Collections.singleton("com.microsoft.sqlserver.jdbc.SQLServerDriver"),
             Collections.singleton("mssql"), "(SELECT DATEDIFF_BIG(ms, '1970-01-01', GETUTCDATE()))");
   }
 

--- a/eventuate-common-jdbc/src/main/java/io/eventuate/common/jdbc/sqldialect/MySqlDialect.java
+++ b/eventuate-common-jdbc/src/main/java/io/eventuate/common/jdbc/sqldialect/MySqlDialect.java
@@ -5,12 +5,11 @@ import io.eventuate.common.jdbc.JdbcUrlParser;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Optional;
 
 public class MySqlDialect extends AbstractEventuateSqlDialect {
 
   public MySqlDialect() {
-    super(Optional.of("com.mysql.cj.jdbc.Driver"),
+    super(new HashSet<>(Arrays.asList("com.mysql.cj.jdbc.Driver", "com.mysql.jdbc.Driver")),
             Collections.unmodifiableSet(new HashSet<>(Arrays.asList("mysql", "mariadb"))),
             "ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 1000)");
   }

--- a/eventuate-common-jdbc/src/main/java/io/eventuate/common/jdbc/sqldialect/PostgresDialect.java
+++ b/eventuate-common-jdbc/src/main/java/io/eventuate/common/jdbc/sqldialect/PostgresDialect.java
@@ -7,7 +7,6 @@ import org.postgresql.util.PGobject;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -16,7 +15,7 @@ public class PostgresDialect extends AbstractEventuateSqlDialect {
   private ConcurrentMap<ColumnCacheKey, String> columnTypeCache = new ConcurrentHashMap<>();
 
   public PostgresDialect() {
-    super(Optional.of("org.postgresql.Driver"),
+    super(Collections.singleton("org.postgresql.Driver"),
             Collections.unmodifiableSet(new HashSet<>(Arrays.asList("postgresql", "pgsql", "pg"))),
             "(ROUND(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000))");
   }


### PR DESCRIPTION
PR adds support for several database driver classes.
It solves this fail: https://app.circleci.com/pipelines/github/eventuate-tram/eventuate-tram-core/59/workflows/6d5a24d0-abc8-422a-90f3-ed6df20cc163/jobs/813
Fail appeared, because mysql driver is updated in eventuate common, but not in eventuate tram.