### PR TITLE
Fix remove of write-protected file during postgres initialization

### DIFF
--- a/postgres/0.activate-additional-scripts.sh
+++ b/postgres/0.activate-additional-scripts.sh
@@ -1,13 +1,13 @@
 #! /bin/bash
 
 if [[ "${USE_JSON_PAYLOAD_AND_HEADERS}" == "true" ]]; then
-  rm /docker-entrypoint-initdb.d/4.initialize-database-json.sql
+  rm -f /docker-entrypoint-initdb.d/4.initialize-database-json.sql
   cp /additional-scripts/4.initialize-database-json.sql docker-entrypoint-initdb.d
   echo "4.initialize-database-json.sql is activated"
 fi
 
 if [[ "${USE_DB_ID}" == "true" ]]; then
-  rm /docker-entrypoint-initdb.d/5.initialize-database-db-id.sql
+  rm -f /docker-entrypoint-initdb.d/5.initialize-database-db-id.sql
   cp /additional-scripts/5.initialize-database-db-id.sql docker-entrypoint-initdb.d
   echo "5.initialize-database-db-id.sql is activated"
 fi


### PR DESCRIPTION
If the `USE_JSON_PAYLOAD_AND_HEADERS` or `USE_DB_ID` flags are used, a file must be removed when Postgres is started.
However, this file is write-protected. If the container is started with `-it`, the user will be asked the following question:

```log
rm: remove write-protected regular empty file '/docker-entrypoint-initdb.d/5.initialize-database-db-id.sql'?
```

This file must be removed. If not, the initialization of Postgres will fail (`Permission denied`).
Therefore, I suggest removing the files with the force option (`rm -f`).